### PR TITLE
Include option for including CSV Header

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,16 @@ var fs           = require('fs'),
     R            = require('ramda'),
     json2csv     = require('json2csv');
 
-module.exports = function toCSV(records, fileName) {
+module.exports = function toCSV(records, fileName, header) {
+    
   if (!records.length) throw 'Error - Array is empty';
-
-  var fields = {data: records, fields: R.keys(records[0])};
-
+  
+  if( !header ) header = false
+    
+  var options = {data: records, fields: R.keys(records[0]), hasCSVColumnTitle: header};
+    
   return new Promise(function(resolve, reject) {
-    json2csv(fields, function(err, csv) {
+    json2csv(options, function(err, csv) {
       if (err) reject(err);
       fs.writeFile(fileName, csv, function(err) {
         return !err ? resolve() : reject(err);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function toCSV(records, fileName, header) {
     
   if (!records.length) throw 'Error - Array is empty';
   
-  if( !header ) header = false
+  if( typeof header === "undefined" ) header = true //default: true, fallback to original functionality
     
   var options = {data: records, fields: R.keys(records[0]), hasCSVColumnTitle: header};
     


### PR DESCRIPTION
- [x] Graceful Fallback

Quick and dirty, in reality, *all* options from `json2csv` should be exposed in this abstraction. 

Resolves #1