### PR TITLE
Fixes typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,8 @@ jsonToCSV(o, fileName)
 .then(() => {
   // success
 })
-.catch(error => {
+.catch((error) => {
+  console.log(error);
   // handle error
 })
 ```


### PR DESCRIPTION
This PR fixes a typo in the example JS code provided in the README.